### PR TITLE
Move the received message ack to after the callback is processed.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,7 +68,7 @@ sourceSets {
 dependencies {
 //    compile fileTree(dir: 'libs', include: ['*.jar'])       // use a local build from libs
 
-    compile 'com.google.code.gson:gson:2.3'
+//    compile 'com.google.code.gson:gson:2.3'
 
     compile 'com.magnet.mmx:mmx-common-api:2.0.0-SNAPSHOT'
     compile 'com.magnet.mmx.ext:mmx-asmack-android-8:4.0.7p3'
@@ -83,7 +83,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 23
     buildToolsVersion "22.0.1"
 
     defaultConfig {

--- a/android/src/main/java/com/magnet/mmx/client/api/MMX.java
+++ b/android/src/main/java/com/magnet/mmx/client/api/MMX.java
@@ -44,6 +44,7 @@ import com.magnet.mmx.client.MMXClientConfig;
 import com.magnet.mmx.client.common.Log;
 import com.magnet.mmx.client.common.MMXErrorMessage;
 import com.magnet.mmx.client.common.MMXPayload;
+import com.magnet.mmx.client.common.MessageHandlingException;
 import com.magnet.mmx.protocol.Constants;
 import com.magnet.mmx.protocol.MMXError;
 import com.magnet.mmx.protocol.MMXTopic;
@@ -304,10 +305,13 @@ public final class MMX {
           notifyInviteResponseReceived(inviteResponse);
         }
       } else {
+
         MMXMessage message = MMXMessage.fromMMXMessage(null, mmxMessage);
         if (message != null) {
           message.receiptId(receiptId);
           notifyMessageReceived(message);
+        } else {
+          throw new MessageHandlingException("Unable to handle message.");
         }
       }
     }

--- a/common/src/main/java/com/magnet/mmx/client/common/MessageHandlingException.java
+++ b/common/src/main/java/com/magnet/mmx/client/common/MessageHandlingException.java
@@ -1,0 +1,17 @@
+package com.magnet.mmx.client.common;
+
+/**
+ * An internal exception used to indicate what the message
+ * listener was unable to handle the message.  Meant to be thrown
+ * when handling a onMessageReceived to prevent the ack from being
+ * sent.
+ */
+public class MessageHandlingException extends RuntimeException {
+  public MessageHandlingException(String message) {
+    super(message);
+  }
+
+  public MessageHandlingException(Throwable t) {
+    super(t);
+  }
+}


### PR DESCRIPTION
This is for delaying the received-message ack until after the listener has been called.
